### PR TITLE
ignore specific lines while parsing

### DIFF
--- a/src/HAB/Pica/Parser/PicaPlainParser.php
+++ b/src/HAB/Pica/Parser/PicaPlainParser.php
@@ -38,10 +38,12 @@ class PicaPlainParser implements PicaPlainParserInterface
     {
         $field = array('subfields' => array());
         $match = array();
-        if (preg_match('#^([012][0-9]{2}[A-Z@])(/([0-9]{2}))? (\$.*)$#Du', $line, $match)) {
+        if (preg_match('#^([012][0-9]{2}[A-Z@])(/([0-9]{2}))?(\s*)(\$.*)$#Du', $line, $match)) {
             $field = array('tag' => $match[1],
                            'occurrence' => $match[3] ?: null,
-                           'subfields' => $this->parseSubfields($match[4]));;
+                           'subfields' => $this->parseSubfields($match[5]));;
+        } else if (preg_match("/^[a-z]{3}\:\s[\d]+/", $line)) {
+            return false;
         } else {
             throw new RuntimeException("Invalid characters in PicaPlain record at line: {$line}");
         }

--- a/src/HAB/Pica/Reader/PicaPlainReader.php
+++ b/src/HAB/Pica/Reader/PicaPlainReader.php
@@ -78,7 +78,10 @@ class PicaPlainReader extends Reader
             $record = array('fields' => array());
             do {
                 $line = current($this->_data);
-                $record['fields'] []= $this->_parser->parseField($line);
+                $field = $this->_parser->parseField($line);
+                if ($field !== false) {
+                    $record['fields'] []= $field;
+                }
             } while (next($this->_data));
             next($this->_data);
         }


### PR DESCRIPTION
+ Allow more delimiter spaces between field code and subfields.
+ ignore lines which matching /^[a-z]{3}\:\s[\d]+/ (that's maybe a HeBIS specific issue) 
Pica record starts (in out case) with line 

Level 0:
<code>
<pre>
alg: 82946326
001@    $03 $aS 
...
</pre>
</code>
Level 1:
<code>
<pre>
lok: 82946326 3
</pre>
</code>
Level 2:
<code>
<pre>
exp: 82946326 3 1 #EPN
201B/01 $011-05-12 $t08:10:38.000 
...
</pre>
</code>